### PR TITLE
将tools/codegen.py读入json文件时的编码更改为UTF-8

### DIFF
--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -685,7 +685,7 @@ def main():
     if config_dir:
         config_dir += "/"
 
-    f = open(config_path, "r")
+    f = open(config_path, "r", encoding='utf8')
     try:
         thingmodel = json.load(f)
         if 'properties' not in thingmodel:


### PR DESCRIPTION
从腾讯云直接保存的json为UTF-8格式，如果不做此更改，则会报错“错误：文件格式非法，请检查xxxxx 文件是否是 JSON 格式。”

更改后可以直接正常运行

 Changes to be committed:
	modified:   tools/codegen.py